### PR TITLE
fix to reverse lookup for login url

### DIFF
--- a/src/accounts/views.py
+++ b/src/accounts/views.py
@@ -15,6 +15,7 @@ User = get_user_model()
 class LoginView(bracesviews.AnonymousRequiredMixin,
                 authviews.LoginView):
     template_name = "accounts/login.html"
+    success_url = reverse_lazy('home')
     form_class = forms.LoginForm
 
     def form_valid(self, form):


### PR DESCRIPTION
This was needed in my environment in order to resolve a 500 on login. Sign up redirected appropriately, so I looked into the code and saw that the sign up view had this success_url defined but the login view did not.
